### PR TITLE
Include detail about excessive downloads in email notification

### DIFF
--- a/Source/Data/SQL Server/_openMIC.sql
+++ b/Source/Data/SQL Server/_openMIC.sql
@@ -213,7 +213,61 @@ CREATE TABLE DranetzTrendingCheckpoint
 )
 GO
 
+--------------------------------------------------------------------------------
 
+-- The following procedure is used by the StatusLog_Email trigger that follows
+-- and appears to have been taken from StackOverflow
+-- https://stackoverflow.com/a/29708178
+
+-- Description: Turns a query into a formatted HTML table. Useful for emails.
+-- Any ORDER BY clause needs to be passed in the separate ORDER BY parameter.
+-- =============================================
+--CREATE PROC [dbo].[spQueryToHtmlTable]
+--(
+--  @query nvarchar(MAX), --A query to turn into HTML format. It should not include an ORDER BY clause.
+--  @orderBy nvarchar(MAX) = NULL, --An optional ORDER BY clause. It should contain the words 'ORDER BY'.
+--  @html nvarchar(MAX) = NULL OUTPUT --The HTML output of the procedure.
+--)
+--AS
+--BEGIN
+--  SET NOCOUNT ON;
+--
+--  IF @orderBy IS NULL BEGIN
+--    SET @orderBy = ''
+--  END
+--
+--  SET @orderBy = REPLACE(@orderBy, '''', '''''');
+--
+--  DECLARE @realQuery nvarchar(MAX) = '
+--    DECLARE @headerRow nvarchar(MAX);
+--    DECLARE @cols nvarchar(MAX);
+--
+--    SELECT * INTO #dynSql FROM (' + @query + ') sub;
+--
+--    SELECT @cols = COALESCE(@cols + '', '''''''', '', '''') + ''SUBSTRING(CAST(['' + name + ''] as nvarchar(max)),1,1000) AS ''''td''''''
+--    FROM tempdb.sys.columns
+--    WHERE object_id = object_id(''tempdb..#dynSql'')
+--    ORDER BY column_id;
+--
+--    SET @cols = ''SET @html = CAST(( SELECT '' + @cols + '' FROM #dynSql ' + @orderBy + ' FOR XML PATH(''''tr''''), ELEMENTS XSINIL) AS nvarchar(max))''
+--
+--    EXEC sys.sp_executesql @cols, N''@html nvarchar(MAX) OUTPUT'', @html=@html OUTPUT
+--
+--    SELECT @headerRow = COALESCE(@headerRow + '''', '''') + ''<th>'' + name + ''</th>''
+--    FROM tempdb.sys.columns
+--    WHERE object_id = object_id(''tempdb..#dynSql'')
+--    ORDER BY column_id;
+--
+--    SET @headerRow = ''<tr>'' + @headerRow + ''</tr>'';
+--
+--    SET @html = ''<table border="1">'' + @headerRow + @html + ''</table>'';
+--    ';
+--
+--  EXEC sys.sp_executesql @realQuery, N'@html nvarchar(MAX) OUTPUT', @html=@html OUTPUT
+--END
+--GO
+
+--------------------------------------------------------------------------------
 
 -- This trigger can be used to get email notifications from the database on status log update
 -- make a semicolon separated list of recipients in the @recipents field and set the db email service name in the @profile_name field
@@ -222,94 +276,95 @@ GO
 -- This trigger will need to be updated before it will work with LocalSchemaVersion 2.
 
 --CREATE TRIGGER [dbo].[StatusLog_Email]
---   ON  [dbo].[StatusLog]
---   AFTER UPDATE
+--  ON  [dbo].[StatusLog]
+--  AFTER UPDATE
 --AS
 --BEGIN
-
---	SET NOCOUNT ON;
-
---	DECLARE @html nvarchar(MAX);
-
---	SELECT * INTO #inserted FROM inserted
---	--SELECT * FROM #inserted
-
---	DECLARE @date DATETIME = GETUTCDATE()
---	DECLARE @deviceID int =  (Select TOP 1 DeviceID from #inserted)
---	DECLARE @enabled bit = (SELECT [Enabled] FROM Device WHERE ID = @deviceID)
-
---	EXEC spQueryToHtmlTable @html = @html OUTPUT,  @query = N'SELECT * FROM #inserted';
---	DECLARE @recipients nvarchar(max) = (SELECT Value FROM Setting WHERE Name = 'EmailRecipients')
---	DECLARE @profile_name nvarchar(max) = (SELECT Value FROM Setting WHERE Name = 'SqlServerEmailProfile')
---	DECLARE @downloadThreshholdWindow int = (SELECT Value FROM Setting WHERE Name = 'MaxDownloadThresholdTimeWindow')
---	DECLARE @downloadThreshhold int = (SELECT Value FROM Setting WHERE Name = 'MaxDownloadThreshold')
---	DECLARE @downloadCount int = (SELECT COUNT(*) FROM DownloadedFile WHERE Timestamp BETWEEN DATEADD(HOUR, -@downloadThreshholdWindow, @date) AND @date AND DeviceID = @deviceID)
-
---	DECLARE @message nvarchar(MAX) = (SELECT TOP 1 Message FROM inserted)
---	DECLARE @name nvarchar(max) = (SELECT Name FROM Device WHERE ID = @deviceID)
---	DECLARE @lastFile nvarchar(max) = (SELECT TOP 1 LastFile FROM inserted)
---	DECLARE @downloadDate nvarchar(max) = (SELECT TOP 1 FileDownloadTimestamp FROM inserted)
---	DECLARE @lastSuccess DateTime = (SELECT LastSuccess FROM StatusLog WHERE DeviceID = @deviceID)
---	DECLARE @lastFailure DateTime = (SELECT LastFailure FROM StatusLog WHERE DeviceID = @deviceID)
---	DECLARE @fileSize int = (SELECT TOP 1 FileSize FROM DownloadedFile WHERE DeviceID = @deviceID ORDER BY ID DESC)
---	DECLARE @fileDate DateTime = (SELECT TOP 1 FileDownloadTimeStamp FROM #inserted)
-
-
---	DECLARE @downloadDateDiff int = (SELECT DATEDIFF(HOUR, @fileDate, @downloadDate))
---	DECLARE @successDateDiff int = (SELECT DATEDIFF(HOUR, @lastSuccess, @lastFailure))
---	DECLARE @emailFlag bit = 0;
---	DECLARE @intro nvarchar(max) = N''
---	DECLARE @emailCountToday int = (SELECT COUNT(*) FROM SentEmail WHERE DeviceID = @deviceID AND Timestamp > CAST(@date as DATE))
-
---	IF @downloadThreshhold > 0 AND @downloadCount > @downloadThreshhold AND @enabled = 1
---	BEGIN
---		SET @intro = @intro + N'<div>'+ @Name+' has been disabled due to excessive downloads.</div><br>'
---		SET @emailFlag = 1
---		UPDATE Device set [Enabled] = 0 WHERE ID = @deviceID
---	END
-
---	IF @fileDate > @date AND @enabled = 1 AND @emailCountToday = 0
---	BEGIN
---		SET @intro = @intro + N'<div>'+ @Name+' has produced a record in the future.</div><br>'
---		SET @emailFlag = 1
---	END
-
---	IF @downloadDateDiff > 12 AND @enabled = 1 AND @emailCountToday = 0
---	BEGIN
---		SET @intro = @intro + N'<div>'+ @Name+' has taken '+ CAST(@downloadDateDiff as nvarchar(100)) +' hours to download a file.  The meter may require attention.</div><br>'
---		SET @emailFlag = 1
---	END
-
---	IF @successDateDiff > 24 AND @enabled = 1 AND @emailCountToday = 0
---	BEGIN
---		SET @intro = @intro + N'<div>'+ @Name+' has not had a successful connection in  '+ CAST(@successDateDiff as nvarchar(100)) +' hours.  The meter may require attention.</div><br>'
---		SET @emailFlag = 1
---	END
-
---	IF @fileSize > 1028*50 AND @enabled = 1 AND @emailCountToday = 0 -- email on greater than 50 MB
---	BEGIN
---		SET @intro = @intro + N'<div>'+ @Name+' has produced a record that is too large.</div><br>'
---		SET @emailFlag = 1
---	END
-
-
---	IF @emailFlag = 1
---	BEGIN
---		SET @html = @intro + @html;
---		DECLARE @subject nvarchar(max) = N'OpenMIC '+ @Name +' problems ...'
---		EXEC msdb.dbo.sp_send_dbmail
---			@profile_name =	@profile_name,
---			@recipients= @recipients,
---			@subject = @subject,
---			@body = @html,
---			@body_format = 'HTML';
-
---		INSERT INTO SentEmail (DeviceID, [Message],[Timestamp]) VALUES ( @deviceID, @html, @date)
-
---	END
-
---	DROP Table #inserted
-
+--
+--    SET NOCOUNT ON;
+--
+--    DECLARE @html nvarchar(MAX);
+--
+--    SELECT * INTO #inserted FROM inserted
+--    --SELECT * FROM #inserted
+--
+--    DECLARE @deviceID int =  (Select TOP 1 DeviceID from #inserted)
+--    DECLARE @enabled bit = (SELECT [Enabled] FROM Device WHERE ID = @deviceID)
+--
+--    EXEC spQueryToHtmlTable @html = @html OUTPUT,  @query = N'SELECT * FROM #inserted';
+--    DECLARE @recipients nvarchar(max) = (SELECT Value FROM Setting WHERE Name = 'EmailRecipients')
+--    DECLARE @downloadThreshholdWindow int = (SELECT Value FROM Setting WHERE Name = 'MaxDownloadThresholdTimeWindow')
+--    DECLARE @downloadThreshhold int = (SELECT Value FROM Setting WHERE Name = 'MaxDownloadThreshold')
+--    DECLARE @date DATETIME = GETUTCDATE()
+--    DECLARE @downloadCount int = (SELECT COUNT(*) FROM (SELECT DISTINCT FilePath FROM DownloadedFile WHERE Timestamp BETWEEN DATEADD(HOUR, -@downloadThreshholdWindow, @date) AND @date AND DeviceID = @deviceID) as thingy)
+--
+--    DECLARE @message nvarchar(MAX) = (SELECT TOP 1 LastErrorMessage FROM inserted)
+--    DECLARE @name nvarchar(max) = (SELECT Name FROM Device WHERE ID = @deviceID)
+--    DECLARE @downloadDate nvarchar(max) = (SELECT TOP 1 LastDownloadStartTime FROM inserted)
+--    DECLARE @lastDownloadedFileID INT = (SELECT TOP 1 LastDownloadedFileID FROM inserted)
+--    DECLARE @lastSuccess DateTime = (SELECT LastRun FROM StatusLog WHERE DeviceID = @deviceID)
+--    DECLARE @lastFailure DateTime = (SELECT LastFailure FROM StatusLog WHERE DeviceID = @deviceID)
+--    DECLARE @fileSize int = (SELECT TOP 1 FileSize FROM DownloadedFile WHERE DeviceID = @deviceID ORDER BY ID DESC)
+--    DECLARE @fileDate DateTime = (SELECT TOP 1 Timestamp FROM DownloadedFile WHERE ID = @lastDownloadedFileID)
+--
+--
+--    DECLARE @downloadDateDiff int = (SELECT DATEDIFF(HOUR, (Select LastDownloadStartTime FROM #inserted), (SELECT LastDownloadEndTime From #inserted)))
+--    DECLARE @successDateDiff int = (SELECT DATEDIFF(HOUR, @lastSuccess, @lastFailure))
+--    DECLARE @emailFlag bit = 0;
+--    DECLARE @intro nvarchar(max) = N''
+--    DECLARE @emailCountToday int = (SELECT COUNT(*) FROM SentEmail WHERE DeviceID = @deviceID AND Timestamp > CAST(@date as DATE))
+--
+--    IF @downloadThreshhold > 0 AND @downloadCount > @downloadThreshhold AND @enabled = 1
+--    BEGIN
+--        DECLARE @countText NVARCHAR(MAX) = CONVERT(NVARCHAR(MAX), @downloadCount)
+--        DECLARE @windowText NVARCHAR(MAX) = CONVERT(NVARCHAR(MAX), @downloadThreshholdWindow)
+--        DECLARE @hourText NVARCHAR(MAX) = CASE @downloadThreshholdWindow WHEN 1 THEN 'hour' ELSE 'hours' END
+--        DECLARE @detailText NVARCHAR(MAX) = @countText + ' files in the last ' + @windowText + ' ' + @hourText
+--        SET @intro = @intro + N'<div>'+ @Name+' has been disabled due to excessive downloads (' + @detailText + ').</div><br>'
+--        SET @emailFlag = 1
+--        UPDATE Device set [Enabled] = 0 WHERE ID = @deviceID
+--    END
+--
+--    IF @fileDate > DATEADD(HOUR, 24, @date) AND @enabled = 1 AND @emailCountToday = 0
+--    BEGIN
+--        SET @intro = @intro + N'<div>'+ @Name+' has produced a record in the future.</div><br>'
+--        SET @emailFlag = 1
+--    END
+--
+--    IF @downloadDateDiff > 12 AND @enabled = 1 AND @emailCountToday = 0
+--    BEGIN
+--        SET @intro = @intro + N'<div>'+ @Name+' has taken '+ CAST(@downloadDateDiff as nvarchar(100)) +' hours to download a file.  The meter may require attention.</div><br>'
+--        SET @emailFlag = 1
+--    END
+--
+--    IF @successDateDiff > 24 AND @enabled = 1 AND @emailCountToday = 0
+--    BEGIN
+--        SET @intro = @intro + N'<div>'+ @Name+' has not had a successful connection in  '+ CAST(@successDateDiff as nvarchar(100)) +' hours.  The meter may require attention.</div><br>'
+--        SET @emailFlag = 1
+--    END
+--
+--    IF @fileSize > 1024*1024*50 AND @enabled = 1 AND @emailCountToday = 0 -- email on greater than 50 MB
+--    BEGIN
+--        SET @intro = @intro + N'<div>'+ @Name+' has produced a record that is too large.</div><br>'
+--        SET @emailFlag = 1
+--    END
+--
+--
+--    IF @emailFlag = 1
+--    BEGIN
+--        SET @html = @intro + @html;
+--        DECLARE @subject nvarchar(max) = N'OpenMIC '+ @Name +' problems ...'
+--        EXEC msdb.dbo.sp_send_dbmail
+--            @recipients= @recipients,
+--            @subject = @subject,
+--            @body = @html,
+--            @body_format = 'HTML';
+--
+--        INSERT INTO SentEmail (DeviceID, [Message],[Timestamp]) VALUES ( @deviceID, @html, @date)
+--
+--    END
+--
+--    DROP Table #inserted
+--
 --END
-
 --GO


### PR DESCRIPTION
Testing reveals that `StatusLog_Email` was outdated and the `CREATE TRIGGER` statement wouldn't run without errors. I updated this to more closely match what we deployed at TVA. Also, I added more detail to the excessive download notification per Ticket_1500.