### PR TITLE
MIC-17 Ensure that TrackedChange table doesn't grow indefinitely

### DIFF
--- a/Source/Data/MySQL/_openMIC.sql
+++ b/Source/Data/MySQL/_openMIC.sql
@@ -2,7 +2,7 @@
 -- IMPORTANT NOTE: When making updates to this schema, please increment the version number!
 -- *******************************************************************************************
 CREATE VIEW LocalSchemaVersion AS
-SELECT 6 AS VersionNumber;
+SELECT 7 AS VersionNumber;
 
 CREATE TABLE Setting(
     ID INT AUTO_INCREMENT NOT NULL,
@@ -139,6 +139,17 @@ DROP VIEW TrackedTable;
 
 CREATE VIEW TrackedTable AS
 SELECT 'Measurement' AS Name  WHERE 1 < 0;
+
+-- MySQL doesn't support INSTEAD OF triggers.
+-- TrackedChange table will grow, but you can use the event scheduler to clear it.
+-- https://dev.mysql.com/doc/refman/8.4/en/events-configuration.html
+--
+--   CREATE EVENT TrackedChange_ClearTable
+--       ON SCHEDULE
+--           EVERY 1 DAY
+--       COMMENT 'Descriptive comment'
+--       DO
+--           TRUNCATE TrackedChange;
 
 ALTER TABLE ConnectionProfile ADD CONSTRAINT FK_ConnectionProfile_ConnectionProfileTaskQueue FOREIGN KEY(DefaultTaskQueueID) REFERENCES ConnectionProfileTaskQueue (ID);
 ALTER TABLE ConnectionProfileTask ADD CONSTRAINT FK_ConnectionProfileTask_ConnectionProfile FOREIGN KEY(ConnectionProfileID) REFERENCES ConnectionProfile (ID);

--- a/Source/Data/Oracle/_openMIC.sql
+++ b/Source/Data/Oracle/_openMIC.sql
@@ -2,7 +2,7 @@
 -- IMPORTANT NOTE: When making updates to this schema, please increment the version number!
 -- *******************************************************************************************
 CREATE VIEW LocalSchemaVersion AS
-SELECT 6 AS VersionNumber
+SELECT 7 AS VersionNumber
 FROM dual;
 
 CREATE TABLE Setting(
@@ -269,3 +269,14 @@ DROP VIEW TrackedTable;
 
 CREATE VIEW TrackedTable AS
 SELECT 'Measurement' AS Name FROM dual WHERE 1 < 0;
+
+RENAME TrackedChange TO TrackedChange_dummy;
+
+CREATE VIEW TrackedChange AS
+SELECT * FROM TrackedChange_dummy;
+
+CREATE TRIGGER CLR_TrackedChange INSTEAD OF INSERT ON TrackedChange
+BEGIN
+    dbms_output.put_line('Suppressed insert into TrackedChange');
+END;
+/

--- a/Source/Data/PostgreSQL/_openMIC.sql
+++ b/Source/Data/PostgreSQL/_openMIC.sql
@@ -2,7 +2,7 @@
 -- IMPORTANT NOTE: When making updates to this schema, please increment the version number!
 -- *******************************************************************************************
 CREATE VIEW LocalSchemaVersion AS
-SELECT 6 AS VersionNumber;
+SELECT 7 AS VersionNumber;
 
 CREATE TABLE Setting(
     ID SERIAL NOT NULL PRIMARY KEY,
@@ -128,6 +128,21 @@ DROP VIEW TrackedTable;
 
 CREATE VIEW TrackedTable AS
 SELECT 'Measurement' AS Name  WHERE 1 < 0;
+
+ALTER TABLE TrackedChange RENAME TO TrackedChange_dummy;
+
+CREATE VIEW TrackedChange AS
+SELECT * FROM TrackedChange_dummy;
+
+CREATE FUNCTION TrackedChange_ClearTableFn() RETURNS TRIGGER
+AS $TrackedChange_ClearTableFn$
+BEGIN
+    RETURN NULL;
+END;
+$TrackedChange_ClearTableFn$ LANGUAGE plpgsql;
+
+CREATE TRIGGER TrackedChange_ClearTable INSTEAD OF INSERT ON TrackedChange
+FOR EACH ROW EXECUTE PROCEDURE TrackedChange_ClearTableFn();
 
 CREATE INDEX IX_DownloadedFile_DeviceID ON DownloadedFile (DeviceID);
 CREATE INDEX IX_DownloadedFile_FilePath ON DownloadedFile (FilePath);

--- a/Source/Data/SQL Server/_openMIC.sql
+++ b/Source/Data/SQL Server/_openMIC.sql
@@ -2,7 +2,7 @@
 -- IMPORTANT NOTE: When making updates to this schema, please increment the version number!
 -- *******************************************************************************************
 CREATE VIEW [dbo].[LocalSchemaVersion] AS
-SELECT 6 AS VersionNumber
+SELECT 7 AS VersionNumber
 GO
 
 CREATE TABLE Setting
@@ -218,6 +218,15 @@ GO
 
 CREATE VIEW TrackedTable AS
 SELECT 'Measurement' AS Name  WHERE 1 < 0
+GO
+
+CREATE TRIGGER TrackedChange_ClearTable
+    ON TrackedChange
+    INSTEAD OF INSERT
+AS
+BEGIN
+	PRINT 'Suppressed insert into TrackedChange'
+END
 GO
 
 --------------------------------------------------------------------------------

--- a/Source/Data/SQLite/_openMIC.sql
+++ b/Source/Data/SQLite/_openMIC.sql
@@ -2,7 +2,7 @@
 -- IMPORTANT NOTE: When making updates to this schema, please increment the version number!
 -- *******************************************************************************************
 CREATE VIEW LocalSchemaVersion AS
-SELECT 6 AS VersionNumber;
+SELECT 7 AS VersionNumber;
 
 CREATE TABLE Setting(
     ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -129,6 +129,15 @@ DROP VIEW TrackedTable;
 CREATE VIEW TrackedTable AS
 SELECT 'Measurement' AS Name  WHERE 1 < 0;
 
+ALTER TABLE TrackedChange RENAME TO TrackedChange_dummy;
+
+CREATE VIEW TrackedChange AS
+SELECT * FROM TrackedChange_dummy;
+
+CREATE TRIGGER TrackedChange_ClearTable INSTEAD OF INSERT ON TrackedChange
+BEGIN
+    SELECT * FROM TrackedChange_dummy WHERE 1 IS NULL;
+END;
 
 CREATE INDEX IX_DownloadedFile_DeviceID ON DownloadedFile (DeviceID);
 CREATE INDEX IX_DownloadedFile_FilePath ON DownloadedFile (FilePath);


### PR DESCRIPTION
Uses `INSTEAD OF` triggers to prevent inserts rather than dropping/altering triggers.

Replaces #22