### PR TITLE
MIC-9 Implement requeue for external operations

### DIFF
--- a/Source/Applications/openMIC/openMIC/Downloader.cs
+++ b/Source/Applications/openMIC/openMIC/Downloader.cs
@@ -2083,7 +2083,7 @@ public class Downloader : InputAdapterBase
         if (connectionSuccessMatch.Success)
         {
             logType = LogType.ConnectionSuccess;
-            patternMessage = downloadedFileMatch.Groups["Message"].Value;
+            patternMessage = connectionSuccessMatch.Groups["Message"].Value;
             LogOutcome(ProgressState.Processing);
 
             AttemptedConnections++;
@@ -2099,7 +2099,7 @@ public class Downloader : InputAdapterBase
         if (connectionFailureMatch.Success)
         {
             logType = LogType.ConnectionFailure;
-            patternMessage = downloadedFileMatch.Groups["Message"].Value;
+            patternMessage = connectionFailureMatch.Groups["Message"].Value;
             LogFailure(patternMessage);
 
             AttemptedConnections++;

--- a/Source/Applications/openMIC/openMIC/Downloader.cs
+++ b/Source/Applications/openMIC/openMIC/Downloader.cs
@@ -2005,6 +2005,12 @@ public class Downloader : InputAdapterBase
                 if (HandleExternalOperationMessage(processArgs.Data, out _))
                     return;
 
+                if (processArgs.Data == RequeuePollingTaskTemplate)
+                {
+                    QueueTasksByID(task.Name, QueuePriority.Normal);
+                    return;
+                }
+
                 OnStatusMessage(MessageLevel.Info, processArgs.Data);
                 OnProgressUpdated(this, new ProgressUpdate { Message = processArgs.Data });
             };

--- a/Source/Applications/openMIC/openMIC/SharedAssets/LogFunctions.cs
+++ b/Source/Applications/openMIC/openMIC/SharedAssets/LogFunctions.cs
@@ -61,10 +61,14 @@ namespace openMIC.SharedAssets
 
         public const string LogConnectionFailureTemplate = OperationPrefix + "Log Connection Failure" + OperationSuffix;
 
+        public const string RequeuePollingTaskTemplate = OperationPrefix + "Requeue Polling Task";
+
         public static void LogDownloadedFile(string fileName) => Console.WriteLine(LogDownloadedFileTemplate, fileName);
 
         public static void LogConnectionSuccess(string message) => Console.WriteLine(LogConnectionSuccessTemplate, message);
 
         public static void LogConnectionFailure(string message) => Console.WriteLine(LogConnectionFailureTemplate, message);
+
+        public static void RequeuePollingTask() => Console.WriteLine(RequeuePollingTaskTemplate);
     }
 }


### PR DESCRIPTION
Enables an external operation to indicate that it's not ready and ask the openMIC host to requeue the task automatically.

This implementation is incredibly basic, consisting of only the bare minimum to get the task requeued. It will not track the number of times any individual task was requeued or attempt to throttle the requeue attempts with delays. Requeued tasks will simply be automatically placed at the end of the connection profile task queue at normal priority.