### PR TITLE
MIC-24 Don't cache the remote scheduler address

### DIFF
--- a/Source/Applications/openMIC/openMIC/DataHub.cs
+++ b/Source/Applications/openMIC/openMIC/DataHub.cs
@@ -113,7 +113,6 @@ public partial class DataHub : RecordOperationsHub<DataHub>, IDataSubscriptionOp
     private static readonly char[] s_digits;
     private static readonly HttpClient s_http;
     private static bool? s_useRemoteScheduler;
-    private static string s_remoteSchedulerUri;
     private static HashSet<string> s_allowedSectionMapPaths;
 
     private static readonly string[] s_allowedSectionMaps = { "", "Dranetz", "PQube" };
@@ -132,19 +131,14 @@ public partial class DataHub : RecordOperationsHub<DataHub>, IDataSubscriptionOp
     {
         get
         {
-            if (s_remoteSchedulerUri is null)
-            {
-                // At first queued task, remote scheduler address will be available
-                string remoteSchedulerAddress = OperationsController.RemoteSchedulerAddress;
+            string remoteSchedulerAddress = OperationsController.RemoteSchedulerAddress;
 
-                if (remoteSchedulerAddress is not null)
-                {
-                    Uri webHostUri = Program.Host.Model.Global.WebHostUri;
-                    s_remoteSchedulerUri = $"{webHostUri.Scheme}://{remoteSchedulerAddress}:{webHostUri.Port}";
-                }
-            }
+            // At first queued task, remote scheduler address will be available
+            if (remoteSchedulerAddress is null)
+                return null;
 
-            return s_remoteSchedulerUri;
+            Uri webHostUri = Program.Host.Model.Global.WebHostUri;
+            return $"{webHostUri.Scheme}://{remoteSchedulerAddress}:{webHostUri.Port}";
         }
     }
 


### PR DESCRIPTION
If the head node fails over, `s_remoteSchedulerUri` would be pointing to the wrong host. Avoid caching the value so we can always contact what is, to the best of our knowledge, the active host. Recomputing this interpolated string for every request shouldn't hurt performance considering we are immediately turning right around and using this result in an interpolated string anyway.