### PR TITLE
correct response serialization in DailyStatistics endpoint

### DIFF
--- a/Source/Applications/openMIC/openMIC/Controllers/DailyStatisticsController.cs
+++ b/Source/Applications/openMIC/openMIC/Controllers/DailyStatisticsController.cs
@@ -59,6 +59,9 @@ public class DailyStatisticsController : ModelController<DailyStatisticsRecord>
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// This comes from the DailyStatisticsRecord table rather than the view.
+    /// </remarks>
     [HttpGet]
     public override IHttpActionResult Get([FromUri] string meter = null)
     {
@@ -74,7 +77,8 @@ public class DailyStatisticsController : ModelController<DailyStatisticsRecord>
         using (AdoDataConnection connection = ConnectionFactory())
         {
             TableOperations<DailyStatisticsRecord> tableOp = new(connection);
-            return Ok(tableOp.QueryRecordsWhere("Meter = {0}", meter));
+            System.Collections.Generic.IEnumerable<DailyStatisticsRecord> results = tableOp.QueryRecordsWhere("Meter = {0}", meter);
+            return Ok(JsonConvert.SerializeObject(results));
         }
     }
 


### PR DESCRIPTION
add documentation to clarify the endpoint,
and correctly serialize the query response before sending the response