### PR TITLE
Log messages when Downloader attempts to kill a child process

### DIFF
--- a/Source/Applications/openMIC/openMIC/Downloader.cs
+++ b/Source/Applications/openMIC/openMIC/Downloader.cs
@@ -2357,6 +2357,11 @@ public class Downloader : InputAdapterBase
         return false;
     }
 
+    private void TerminateProcessTree(Process ancestor)
+    {
+        TerminateProcessTree(ancestor, message => OnStatusMessage(MessageLevel.Debug, message));
+    }
+
     #endregion
 
     #region [ Task Logging Handlers ]
@@ -2725,7 +2730,7 @@ public class Downloader : InputAdapterBase
         }
     }
 
-    private static void TerminateProcessTree(Process ancestor)
+    private static void TerminateProcessTree(Process ancestor, Action<string> logDebug)
     {
         try
         {
@@ -2784,8 +2789,11 @@ public class Downloader : InputAdapterBase
             LogException("Failed to terminate process \"{1}\" ({0}): {2}", ex);
         }
 
-        static void Kill(Process process)
+        void Kill(Process process)
         {
+            try { logDebug($"Terminating process {process.Id} ({process.ProcessName})"); }
+            catch { /* Logging error is not critical */ }
+
             try { process.Kill(); }
             catch (ArgumentException) { /* Process already exited */ }
         }


### PR DESCRIPTION
Example messages from openMIC trying to kill a batch file process:

```
Terminating process 29016 (conhost)
Terminating process 37084 (cmd)
Failed to terminate process "cmd" (37084): Access is denied
```

I assume access was denied because killing conhost also resulted in killing cmd so the process no longer existed.